### PR TITLE
Export MediumError to use in tests

### DIFF
--- a/lib/mediumClient.js
+++ b/lib/mediumClient.js
@@ -404,6 +404,7 @@ MediumClient.prototype._makeRequest = function (options, callback) {
 
 module.exports = {
   MediumClient: MediumClient,
+  MediumError: MediumError,
   Scope: Scope,
   PostPublishStatus: PostPublishStatus,
   PostLicense: PostLicense,


### PR DESCRIPTION
There are tests that check if a MediumError is thrown, which will pass even when medium.MediumError is undefined (currently)

Example:
```(function () { new medium.MediumClient() }).should.throw(medium.MediumError)```

This change exports MediumError with the medium module.