### PR TITLE
Fix a typo and remove trailing whitespace in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ var url = client.getAuthorizationUrl('secretState', 'https://yoursite.com/callba
 
 // (Send the user to the authorization URL to obtain an authorization code.)
 
-client.ExchangeAuthorizationCode('YOUR_AUTHORIZATION_CODE', function (err, token) {
+client.exchangeAuthorizationCode('YOUR_AUTHORIZATION_CODE', function (err, token) {
   client.getUser(function (err, user) {
     client.createPost({
       userId: user.id,
       title: 'A new post',
       contentFormat: medium.PostContentFormat.HTML,
       content: '<h1>A New Post</h1><p>This is my new post.</p>',
-      publishStatus: medium.PostPublishStatus.DRAFT 
+      publishStatus: medium.PostPublishStatus.DRAFT
     }, function (err, post) {
       console.log(token, user, post)
     })


### PR DESCRIPTION
Hello @kylehg, @majelbstoat, 

Please review the following commits I made in branch 'chad-readme-typo'.

3aac03447575c58bfcb000c7175a4b6b3668b11e (2016-01-28 20:33:12 -0800)
Fix a typo and remove trailing whitespace in the README.
Fixes https://github.com/Medium/medium-sdk-nodejs/issues/9

R=@kylehg
R=@majelbstoat