### PR TITLE
Support 'publishedAt' when creating posts

### DIFF
--- a/lib/mediumClient.js
+++ b/lib/mediumClient.js
@@ -247,6 +247,7 @@ MediumClient.prototype.createPost = function (options, callback) {
       contentFormat: options.contentFormat,
       tags: options.tags,
       canonicalUrl: options.canonicalUrl,
+      publishedAt: options.publishedAt,
       publishStatus: options.publishStatus,
       license: options.license
     }
@@ -285,6 +286,7 @@ MediumClient.prototype.createPostInPublication = function (options, callback) {
       contentFormat: options.contentFormat,
       tags: options.tags,
       canonicalUrl: options.canonicalUrl,
+      publishedAt: options.publishedAt,
       publishStatus: options.publishStatus,
       license: options.license
     }

--- a/test/mediumClient_test.js
+++ b/test/mediumClient_test.js
@@ -228,6 +228,7 @@ describe('MediumClient - methods', function () {
         contentFormat: 'html',
         tags: ['js', 'unit tests'],
         canonicalUrl: 'http://example.com/new-post',
+        publishedAt: '2004-02-12T15:19:21+00:00',
         publishStatus: 'draft',
         license: 'all-rights-reserved'
       }
@@ -239,6 +240,7 @@ describe('MediumClient - methods', function () {
             contentFormat: options.contentFormat,
             tags: options.tags,
             canonicalUrl: options.canonicalUrl,
+            publishedAt: options.publishedAt,
             publishStatus: options.publishStatus,
             license: options.license
         })
@@ -268,6 +270,7 @@ describe('MediumClient - methods', function () {
         contentFormat: 'html',
         tags: ['js', 'unit tests'],
         canonicalUrl: 'http://example.com/new-post',
+        publishedAt: '2004-02-12T15:19:21+00:00',
         publishStatus: 'draft',
         license: 'all-rights-reserved'
       }
@@ -279,6 +282,7 @@ describe('MediumClient - methods', function () {
             contentFormat: options.contentFormat,
             tags: options.tags,
             canonicalUrl: options.canonicalUrl,
+            publishedAt: options.publishedAt,
             publishStatus: options.publishStatus,
             license: options.license
         })


### PR DESCRIPTION
Per https://github.com/Medium/medium-api-docs/issues/6, this PR adds `publishedAt` as a supported parameter when creating posts for a user or publication. 

Mocha specs updated to cover this param.

(CLA PR is here: https://github.com/Medium/opensource/pull/108)